### PR TITLE
Update button documentation to reference disabled state

### DIFF
--- a/src/components/button/index.md
+++ b/src/components/button/index.md
@@ -63,6 +63,12 @@ Avoid using plain icon-only buttons as they might not have a distinct enough hov
 
 {{ example({ group: "components", item: "button", example: "icon-only", html: true, nunjucks: true, size: "xxxs" }, 2) }}
 
+### Disabled buttons
+
+Because disabled buttons can confuse some users, they have been intentionally omitted from this design system. Avoid them if possible. 
+
+Only use disabled buttons if research with users shows their use makes the user interface easier to understand. 
+
 #### SVG icons
 
 To avoid relying on the Font Awesome CSS and font files, you can embed SVGs directly into the button using `iconSvg`.


### PR DESCRIPTION
### What

This PR introduces content specific to the use of disabled buttons.

<details>
<summary>Screenshot of new content (in page)</summary>

![Screenshot of new content](https://github.com/user-attachments/assets/9a0a9f4d-ef8a-41a3-bea6-8ca29036f964)

</details>

### Why

Following a discussion arising from the use of disabled buttons in WorldPay pages, we discussed the potential to reference them in the design system - primarily for the benefit of third-parties. 

WorldPay hosted payment pages[^1] link the disabled state of several buttons to the state of other fields on the page (for example, a "Make payment" button will be disabled until all required fields have been populated with valid entries).

We are not keen on the use of dynamically updating the disabled state and prefer server-side validation and a consistent user interface for users as they interact with forms.

The content introduced borrows from the GOV.UK Design System [^2] but:

1. Clarifies that disabled buttons have been intentionally omitted
2. Omits the GDS reference to poor contrast (because that is not the case for disabled buttons using our Design System styles)

[^1]: https://developer.worldpay.com/products/access/hosted-payment-pages
[^2]: https://design-system.service.gov.uk/components/button/#disabled-buttons